### PR TITLE
[Feat/#20] 홈화면 구현 및 임시저장 연결

### DIFF
--- a/app/src/main/java/com/sopt/anshim/main/MainActivity.kt
+++ b/app/src/main/java/com/sopt/anshim/main/MainActivity.kt
@@ -9,7 +9,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.sopt.anshim.addbook.AddBookScreen
 import com.sopt.anshim.designsystem.theme.AnshimTheme
-import com.sopt.anshim.home.HomeScreen
+import com.sopt.anshim.home.HomeRoute
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -26,7 +26,7 @@ class MainActivity : ComponentActivity() {
                     startDestination = Route.Home
                 ) {
                     composable<Route.Home> {
-                        HomeScreen(
+                        HomeRoute(
                             navToAddBook = { navigator.navigate(Route.AddBook) }
                         )
                     }

--- a/core/designsystem/src/main/java/com/sopt/anshim/designsystem/component/image/UrlToBitmapImage.kt
+++ b/core/designsystem/src/main/java/com/sopt/anshim/designsystem/component/image/UrlToBitmapImage.kt
@@ -1,0 +1,65 @@
+package com.sopt.anshim.designsystem.component.image
+
+import android.graphics.ImageDecoder
+import android.net.Uri
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun UrlToBitmapImage(
+    imageUri: String,
+    hint: String,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val bitmap = remember(imageUri) {
+        val uri = Uri.parse(imageUri)
+        if(imageUri.isNotBlank()){
+            ImageDecoder.decodeBitmap(
+                ImageDecoder.createSource(context.contentResolver, uri)
+            )
+        } else {
+            null
+        }
+    }
+
+    if (bitmap != null) {
+        Image(
+            bitmap = bitmap.asImageBitmap(),
+            contentDescription = null,
+            modifier = modifier
+        )
+    } else {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = modifier
+        ) {
+            Text(
+                text = hint,
+                color = Color.DarkGray
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun PreviewAddBookImageField() {
+    UrlToBitmapImage(
+        imageUri = "",
+        hint = "image",
+        modifier = Modifier
+            .size(150.dp)
+    )
+}

--- a/feature/addbook/src/main/java/com/sopt/anshim/addbook/AddBookScreen.kt
+++ b/feature/addbook/src/main/java/com/sopt/anshim/addbook/AddBookScreen.kt
@@ -72,6 +72,10 @@ fun AddBookScreen(
             }
     }
 
+    LaunchedEffect(true) {
+        viewModel.onEvent(AddBookEvent.SavedDataExistenceChecked)
+    }
+
     BackHandler {
         viewModel.onEvent(AddBookEvent.BackButtonClicked)
     }

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -37,6 +37,7 @@ android {
 dependencies {
 
     implementation(projects.data.repository)
+    implementation(projects.core.designsystem)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/feature/home/src/main/java/com/sopt/anshim/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/sopt/anshim/home/HomeScreen.kt
@@ -1,48 +1,105 @@
 package com.sopt.anshim.home
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Button
-import androidx.compose.material3.Text
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.sp
+import androidx.compose.ui.unit.dp
+import com.sopt.anshim.home.component.HomeBookGroup
+import com.sopt.anshim.home.component.HomeFloatingButton
+import com.sopt.anshim.home.component.HomeTopBar
+import com.sopt.model.book.Book
 
 @Composable
-fun HomeScreen(
-    navToAddBook: () -> Unit
+fun HomeRoute(
+    navToAddBook: () -> Unit,
+    modifier: Modifier = Modifier,
+    navToDetail: (Book) -> Unit = {},
 ) {
-    Column(
-        Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Text(
-            text = "여긴 HomeScreen",
-            fontSize = 25.sp,
-            fontWeight = FontWeight.Bold
-        )
 
-        Button(
-            onClick = { navToAddBook() }
+    HomeScreen(
+        bookList = emptyList(),
+        onFabClick = navToAddBook,
+        onBookClick = navToDetail,
+        modifier = modifier
+    )
+}
+
+@Composable
+private fun HomeScreen(
+    onBookClick: (Book) -> Unit,
+    onFabClick: () -> Unit,
+    bookList: List<Book>,
+    modifier: Modifier = Modifier,
+) {
+    Scaffold(
+        topBar = {
+            HomeTopBar()
+        },
+        floatingActionButton = {
+            HomeFloatingButton(onClick = onFabClick)
+        }
+    ) { innerPadding ->
+        LazyColumn(
+            modifier = modifier
+                .fillMaxSize()
+                .padding(top = innerPadding.calculateTopPadding()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 10.dp)
         ) {
-            Text(
-                text = "누르면 화면이동",
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Bold
-            )
+            items(bookList) { book ->
+                HomeBookGroup(
+                    book = book,
+                    modifier = Modifier.clickable {
+                        onBookClick(book)
+                    }
+                )
+            }
         }
     }
 }
+
 
 @Preview
 @Composable
 private fun PreviewHomeScreen() {
     HomeScreen(
-        navToAddBook = {}
+        onFabClick = {},
+        onBookClick = {},
+        bookList = listOf(
+            Book(
+                title = "안심이 프로젝트",
+                author = "정안심",
+                image = "",
+                price = "10,000",
+                publisher = "",
+                description = ""
+            ),
+            Book(
+                title = "안심이 프로젝트",
+                author = "정안심",
+                image = "",
+                price = "10,000",
+                publisher = "",
+                description = ""
+            ),
+            Book(
+                title = "안심이 프로젝트",
+                author = "정안심",
+                image = "",
+                price = "10,000",
+                publisher = "",
+                description = ""
+            ),
+        )
     )
 }

--- a/feature/home/src/main/java/com/sopt/anshim/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/sopt/anshim/home/HomeViewModel.kt
@@ -1,12 +1,36 @@
 package com.sopt.anshim.home
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.sopt.anshim.home.contract.HomeUiEvent
+import com.sopt.anshim.home.contract.HomeUiSideEffect
+import com.sopt.anshim.home.contract.HomeUiState
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class HomeViewModel @Inject constructor(
 
 ) : ViewModel() {
+    private val _uiState = MutableStateFlow(HomeUiState())
+    val uiState = _uiState.asStateFlow()
 
+    private val _sideEffect = MutableSharedFlow<HomeUiSideEffect>()
+    val sideEffect = _sideEffect.asSharedFlow()
+
+    fun handleEvent(event: HomeUiEvent) = viewModelScope.launch {
+        when(event) {
+            is HomeUiEvent.OnClickFAB -> {
+                _sideEffect.emit(HomeUiSideEffect.NavigateToAddBook)
+            }
+            is HomeUiEvent.OnSelectBook -> {
+                _sideEffect.emit(HomeUiSideEffect.NavigateToDetail(event.book))
+            }
+        }
+    }
 }

--- a/feature/home/src/main/java/com/sopt/anshim/home/component/HomeBookGroup.kt
+++ b/feature/home/src/main/java/com/sopt/anshim/home/component/HomeBookGroup.kt
@@ -1,0 +1,79 @@
+package com.sopt.anshim.home.component
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.sopt.anshim.designsystem.component.image.UrlToBitmapImage
+import com.sopt.model.book.Book
+
+@Composable
+internal fun HomeBookGroup(
+    book: Book,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .aspectRatio(3.5f),
+        horizontalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        UrlToBitmapImage(
+            imageUri = book.image,
+            hint = "IMAGE",
+            modifier = Modifier
+                .fillMaxHeight()
+                .aspectRatio(1f)
+        )
+
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.spacedBy(8.dp, Alignment.CenterVertically),
+        ) {
+            Text(
+                text = book.title,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = TextStyle.Default.copy(
+                    fontSize = 20.sp
+                )
+            )
+            Text(
+                text = book.author,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                style = TextStyle.Default.copy(
+                    color = Color.Gray
+                )
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun HomeBookGroupPreview() {
+    HomeBookGroup(
+        book = Book(
+            title = "안심이 프로젝트",
+            author = "정안심",
+            image = "",
+            price = "10,000",
+            publisher = "",
+            description = ""
+        )
+    )
+}

--- a/feature/home/src/main/java/com/sopt/anshim/home/component/HomeFloatingButton.kt
+++ b/feature/home/src/main/java/com/sopt/anshim/home/component/HomeFloatingButton.kt
@@ -1,0 +1,50 @@
+package com.sopt.anshim.home.component
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Add
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.FloatingActionButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun HomeFloatingButton(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FloatingActionButton(
+        onClick = onClick,
+        modifier = modifier,
+        elevation = FloatingActionButtonDefaults.elevation(
+            defaultElevation = 3.dp
+        ),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Add,
+            contentDescription = "Add Book"
+        )
+    }
+}
+
+@Preview
+@Composable
+private fun PreviewHomeFloatingButton() {
+    Box(
+        modifier = Modifier
+            .wrapContentSize()
+            .background(color = Color.White)
+            .padding(20.dp)
+    ) {
+        HomeFloatingButton(
+            onClick = {}
+        )
+    }
+}

--- a/feature/home/src/main/java/com/sopt/anshim/home/component/HomeTopBar.kt
+++ b/feature/home/src/main/java/com/sopt/anshim/home/component/HomeTopBar.kt
@@ -1,0 +1,31 @@
+package com.sopt.anshim.home.component
+
+import androidx.compose.material3.CenterAlignedTopAppBar
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun HomeTopBar(
+    modifier: Modifier = Modifier
+) {
+    CenterAlignedTopAppBar(
+        title = {
+            Text(
+                text = "안심 도서"
+            )
+        },
+        modifier = modifier.shadow(elevation = 1.dp)
+    )
+}
+
+@Preview
+@Composable
+private fun PreviewHomeTopBar() {
+    HomeTopBar()
+}

--- a/feature/home/src/main/java/com/sopt/anshim/home/contract/HomeUiEvent.kt
+++ b/feature/home/src/main/java/com/sopt/anshim/home/contract/HomeUiEvent.kt
@@ -1,0 +1,8 @@
+package com.sopt.anshim.home.contract
+
+import com.sopt.model.book.Book
+
+sealed class HomeUiEvent {
+    data object OnClickFAB: HomeUiEvent()
+    data class OnSelectBook(val book: Book): HomeUiEvent()
+}

--- a/feature/home/src/main/java/com/sopt/anshim/home/contract/HomeUiSideEffect.kt
+++ b/feature/home/src/main/java/com/sopt/anshim/home/contract/HomeUiSideEffect.kt
@@ -1,0 +1,8 @@
+package com.sopt.anshim.home.contract
+
+import com.sopt.model.book.Book
+
+sealed class HomeUiSideEffect {
+    data object NavigateToAddBook: HomeUiSideEffect()
+    data class NavigateToDetail(val book: Book): HomeUiSideEffect()
+}

--- a/feature/home/src/main/java/com/sopt/anshim/home/contract/HomeUiState.kt
+++ b/feature/home/src/main/java/com/sopt/anshim/home/contract/HomeUiState.kt
@@ -1,0 +1,7 @@
+package com.sopt.anshim.home.contract
+
+import com.sopt.model.book.Book
+
+data class HomeUiState(
+    val books: List<Book> = emptyList()
+)


### PR DESCRIPTION
## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #20 

## 📎 𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 홈화면 구현
- 임시저장 기능 연결

## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁
| 홈화면 | 임시저장 기능 |
|:-----:|:------------:|
| <img src="https://github.com/user-attachments/assets/ec17480b-d021-4b51-b112-9710bf819233" width=300/> | <video src="https://github.com/user-attachments/assets/6e3c3442-73c6-4735-bda2-5ea65a24622c" width=300/>

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
- 홈화면은 얼추 구현해봤고 상세화면 이동은 화면이 마련되면 이동로직만 넣으면 됩니다!
- DataStore에서 모든 정보를 지워버리는 로직도 하나 있으면 좋을 것 같아요! 현재 임시저장을 삭제할 때 빈값들이 넘어가도록 구현해두었습니다!